### PR TITLE
TALEARNT 342 : 매칭 게시물 리스트 API

### DIFF
--- a/lib/data/model/param/talent_exchange_posts_filter_param
+++ b/lib/data/model/param/talent_exchange_posts_filter_param
@@ -32,7 +32,7 @@ class TalentExchangePostsFilterParam {
         badge = null,
         status = null,
         page = '1',
-        size = '10',
+        size = '15',
         search = null;
 
   Map<String, dynamic> toJson() {

--- a/lib/data/model/param/talent_exchange_posts_filter_param
+++ b/lib/data/model/param/talent_exchange_posts_filter_param
@@ -1,0 +1,52 @@
+class TalentExchangePostsFilterParam {
+  final List<String>? giveTalents; // 주고픈 재능 코드
+  final List<String>? receiveTalents; // 받고픈 재능 코드
+  final String? order; // 정렬 - recent: 최신순, popular: 인기순
+  final String? duration; // 진행 기간 - 기간 미정, 1개월, 2개월, 3개월, 3개월 이상
+  final String? type; // 진행 방식 - 온라인, 오프라인, 온_오프라인
+  final String? badge; // 인증 뱃지 필요 여부 - true, false
+  final String? status; // 모집 상태 - 모집중, 모집_완료
+  final String? page; // 기본값 1
+  final String? size; // 기본값 15, 최대 50
+  final String? search; // 검색어
+
+  TalentExchangePostsFilterParam({
+    this.giveTalents,
+    this.receiveTalents,
+    this.order,
+    this.duration,
+    this.type,
+    this.badge,
+    this.status,
+    this.page = '1',
+    this.size = '15',
+    this.search,
+  });
+
+  TalentExchangePostsFilterParam.empty()
+      : giveTalents = [],
+        receiveTalents = [],
+        order = null,
+        duration = null,
+        type = null,
+        badge = null,
+        status = null,
+        page = '1',
+        size = '10',
+        search = null;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'giveTalents': giveTalents,
+      'receiveTalents': receiveTalents,
+      'order': order,
+      'duration': duration,
+      'type': type,
+      'badge': badge,
+      'status': status,
+      'page': page,
+      'size': size,
+      'search': search,
+    };
+  }
+}

--- a/lib/data/model/respone/pagination.dart
+++ b/lib/data/model/respone/pagination.dart
@@ -1,4 +1,3 @@
-
 class Pagination {
   final bool hasNext;
   final bool hasPrevious;
@@ -11,6 +10,12 @@ class Pagination {
     required this.totalPages,
     required this.currentPage,
   });
+
+  Pagination.empty()
+      : hasNext = false,
+        hasPrevious = false,
+        totalPages = 1,
+        currentPage = 1;
 
   factory Pagination.fromJson(Map<String, dynamic> json) {
     return Pagination(

--- a/lib/data/model/respone/talent_exchange_post.dart
+++ b/lib/data/model/respone/talent_exchange_post.dart
@@ -1,5 +1,3 @@
-import 'package:app_front_talearnt/data/model/respone/pagination.dart';
-
 class TalentExchangePost {
   final String profileImg;
   final String nickname;
@@ -14,9 +12,9 @@ class TalentExchangePost {
   final List<String> giveTalents;
   final List<String> receiveTalents;
   final DateTime createdAt;
-  final int count;
+  final int openedChatRoomCount;
   final int favoriteCount;
-  final Pagination pagination;
+  final bool isFavorite;
 
   TalentExchangePost({
     required this.profileImg,
@@ -32,9 +30,9 @@ class TalentExchangePost {
     required this.giveTalents,
     required this.receiveTalents,
     required this.createdAt,
-    required this.count,
+    required this.openedChatRoomCount,
     required this.favoriteCount,
-    required this.pagination,
+    required this.isFavorite,
   });
 
   factory TalentExchangePost.fromJson(Map<String, dynamic> json) {
@@ -52,9 +50,9 @@ class TalentExchangePost {
       giveTalents: List<String>.from(json['giveTalents']),
       receiveTalents: List<String>.from(json['receiveTalents']),
       createdAt: DateTime.parse(json['createdAt']),
-      count: json['count'],
+      openedChatRoomCount: json['openedChatRoomCount'],
       favoriteCount: json['favoriteCount'],
-      pagination: Pagination.fromJson(json['pagination']),
+      isFavorite: json['isFavorite'],
     );
   }
 
@@ -73,9 +71,9 @@ class TalentExchangePost {
       'giveTalents': giveTalents,
       'receiveTalents': receiveTalents,
       'createdAt': createdAt.toIso8601String(),
-      'count': count,
+      'openedChatRoomCount': openedChatRoomCount,
       'favoriteCount': favoriteCount,
-      'pagination': pagination.toJson(),
+      'isFavorite': isFavorite,
     };
   }
 }

--- a/lib/data/repositories/talent_board_repository.dart
+++ b/lib/data/repositories/talent_board_repository.dart
@@ -1,11 +1,13 @@
 import 'package:app_front_talearnt/data/model/respone/failure.dart';
-import 'package:app_front_talearnt/data/model/respone/keyword_category.dart';
+import 'package:app_front_talearnt/data/model/respone/pagination.dart';
 import 'package:app_front_talearnt/data/model/respone/success.dart';
 import 'package:app_front_talearnt/data/services/dio_service.dart';
 import 'package:dartz/dartz.dart';
 
 import '../../constants/api_constants.dart';
 import '../model/param/my_talent_keywords_param.dart';
+import '../model/param/talent_exchange_posts_filter_param';
+import '../model/respone/talent_exchange_post.dart';
 
 class TalentBoardRepository {
   final DioService dio;
@@ -26,5 +28,17 @@ class TalentBoardRepository {
     final result = await dio.post(
         ApiConstants.setMyTalentKeywordsUrl, body.toJson(), null);
     return result.fold(left, (response) => right(Success.fromJson(response)));
+  }
+
+  Future<Either<Failure, Map<String, dynamic>>> getTalentExchangePosts(
+      TalentExchangePostsFilterParam body) async {
+    final response =
+        await dio.get(ApiConstants.getTalentBoardListUrl, null, body.toJson());
+    return response.fold(left, (response) {
+      final posts = List<TalentExchangePost>.from(
+          response['data'].map((data) => TalentExchangePost.fromJson(data)));
+      final pagination = Pagination.fromJson(response['pagination']);
+      return right({'posts': posts, 'pagination': pagination});
+    });
   }
 }

--- a/lib/data/services/dio_service.dart
+++ b/lib/data/services/dio_service.dart
@@ -16,11 +16,22 @@ class DioService {
     _dio.interceptors.add(interceptor);
   }
 
-  Future<Either<Failure, Map<String, dynamic>>> get(String path,
-      Map<String, dynamic>? data, Map<String, dynamic>? params) async {
+  Future<Either<Failure, dynamic>> get(String path, Map<String, dynamic>? data,
+      Map<String, dynamic>? params) async {
     try {
       var response = await _dio.get(path, queryParameters: params, data: data);
-      return right(response.data as Map<String, dynamic>);
+      if (response.data is List) {
+        return right(response.data as List<dynamic>);
+      } else if (response.data is Map<String, dynamic>) {
+        return right(response.data as Map<String, dynamic>);
+      } else {
+        // 알 수 없는 형태의 데이터
+        return left(Failure(
+          errorCode: 'UNEXPECTED_RESPONSE',
+          errorMessage: 'Unexpected response format',
+          success: false,
+        ));
+      }
     } on DioException catch (e) {
       if (e.response?.statusCode == 401) {
         var result = await handleAuthResponse(e.response, () {

--- a/lib/provider/provider_set_up.dart
+++ b/lib/provider/provider_set_up.dart
@@ -76,16 +76,18 @@ class ProviderSetup extends StatelessWidget {
             create: (_) => KeywordProvider()),
         ChangeNotifierProvider<MatchWriteProvider>(
             create: (_) => MatchWriteProvider()),
+        ChangeNotifierProvider<TalentBoardProvider>(
+            create: (_) => TalentBoardProvider()),
         ChangeNotifierProvider<TalentBoardViewModel>(
           create: (context) => TalentBoardViewModel(
             CommonNavigator(navigatorKey),
             TalentBoardRepository(context.read<DioService>()),
             context.read<KeywordProvider>(),
             context.read<MatchWriteProvider>(),
+            context.read<TalentBoardProvider>(),
           ),
         ),
-        ChangeNotifierProvider<TalentBoardProvider>(
-            create: (_) => TalentBoardProvider()),
+
       ],
       child: child,
     );

--- a/lib/provider/provider_set_up.dart
+++ b/lib/provider/provider_set_up.dart
@@ -87,7 +87,6 @@ class ProviderSetup extends StatelessWidget {
             context.read<TalentBoardProvider>(),
           ),
         ),
-
       ],
       child: child,
     );

--- a/lib/provider/talent_board/talent_board_provider.dart
+++ b/lib/provider/talent_board/talent_board_provider.dart
@@ -1,7 +1,7 @@
+import 'package:app_front_talearnt/data/model/respone/pagination.dart';
 import 'package:flutter/material.dart';
 
 import '../../constants/global_value_constants.dart';
-import '../../data/model/respone/pagination.dart';
 import '../../data/model/respone/talent_exchange_post.dart';
 import '../common/custom_ticker_provider.dart';
 
@@ -25,6 +25,8 @@ class TalentBoardProvider extends ChangeNotifier {
   final List<int> _selectedGiveTalentKeywordCodes = [];
   final List<int> _interestTalentKeywordCodes = [];
   final List<int> _selectedInterestTalentKeywordCodes = [];
+  final List<TalentExchangePost> _talentExchangePosts = [];
+  Pagination _talentPage = Pagination.empty();
 
   TabController get giveTalentTabController => _giveTalentTabController;
 
@@ -46,79 +48,9 @@ class TalentBoardProvider extends ChangeNotifier {
   List<int> get selectedInterestTalentKeywordCodes =>
       _selectedInterestTalentKeywordCodes;
 
-  final List<TalentExchangePost> talentExchangePosts = [
-    TalentExchangePost(
-      profileImg: "유저 이미지",
-      nickname: "테스트",
-      authority: "ROLE_USER",
-      exchangePostNo: 7,
-      status: "모집중",
-      exchangeType: "오프라인",
-      duration: "3개월",
-      requiredBadge: true,
-      title: "일곱 번째 게시글 타이틀 입니다.",
-      content: "일곱 번째 글은 엔터키가 없고 HTML 태그만 있는 겁니다.",
-      giveTalents: ["방송댄스", "힙합.스트릿댄스"],
-      receiveTalents: ["일식 조리"],
-      createdAt: DateTime.parse("2024-12-29T20:38:09.267246"),
-      count: 1,
-      favoriteCount: 0,
-      pagination: Pagination(
-        hasNext: false,
-        hasPrevious: false,
-        totalPages: 1,
-        currentPage: 1,
-      ),
-    ),
-    TalentExchangePost(
-      profileImg: "유저 이미지",
-      nickname: "테스트",
-      authority: "ROLE_USER",
-      exchangePostNo: 6,
-      status: "모집중",
-      exchangeType: "오프라인",
-      duration: "3개월",
-      requiredBadge: true,
-      title: "여섯 번째 게시글 타이틀 입니다.",
-      content:
-          "여섯 번째 게시글 아,맞아 HTML 태그도 있다고 가정하고 이걸 제거하는 방법도 체택해야하고 글자수 20글자까지만 보여준다음에 ... 을 추가해주는 마법을 부려야하는데 HTML 코...",
-      giveTalents: ["부동산 투자", "영유아 발달", "홍보 글쓰기"],
-      receiveTalents: ["메이크업", "콘텐츠 마케팅"],
-      createdAt: DateTime.parse("2024-12-29T20:38:09.267246"),
-      count: 1,
-      favoriteCount: 0,
-      pagination: Pagination(
-        hasNext: false,
-        hasPrevious: false,
-        totalPages: 1,
-        currentPage: 1,
-      ),
-    ),
-    TalentExchangePost(
-      profileImg: "유저 이미지",
-      nickname: "테스트",
-      authority: "ROLE_USER",
-      exchangePostNo: 5,
-      status: "모집중",
-      exchangeType: "오프라인",
-      duration: "3개월",
-      requiredBadge: true,
-      title: "다섯 번째 게시글 타이틀 입니다.",
-      content:
-          "다섯 번째 게시글은 아주 중요한게 떠올랐는데 와 이걸 까먹었네 뇌정지가 씨게 와서 이제는 아무것도 할 수 없는 뇌가 되어버려~ 좌뇌...(자네...)우뇌....?(우네...?)",
-      giveTalents: ["드로잉"],
-      receiveTalents: ["드론 촬영", "사진 촬영", "영상 편집"],
-      createdAt: DateTime.parse("2024-12-29T20:38:09.267246"),
-      count: 1,
-      favoriteCount: 0,
-      pagination: Pagination(
-        hasNext: false,
-        hasPrevious: false,
-        totalPages: 1,
-        currentPage: 1,
-      ),
-    ),
-  ];
+  List<TalentExchangePost> get talentExchangePosts => _talentExchangePosts;
+
+  Pagination get talentPage => _talentPage;
 
   void updateOrderType(String newType) {
     _selectedOrderType = newType;
@@ -188,6 +120,17 @@ class TalentBoardProvider extends ChangeNotifier {
   void matchGiveKeywordList() {
     _giveTalentKeywordCodes.clear();
     _giveTalentKeywordCodes.addAll(_selectedGiveTalentKeywordCodes);
+    notifyListeners();
+  }
+
+  void updateTalentExchangePosts(
+      List<TalentExchangePost> addTalentExchangePosts) {
+    _talentExchangePosts.addAll(addTalentExchangePosts);
+    notifyListeners();
+  }
+
+  void updateTalentExchangePostsPage(Pagination paging) {
+    _talentPage = paging;
     notifyListeners();
   }
 }

--- a/lib/provider/talent_board/talent_board_provider.dart
+++ b/lib/provider/talent_board/talent_board_provider.dart
@@ -22,9 +22,9 @@ class TalentBoardProvider extends ChangeNotifier {
   String _selectedDurationType = '';
   String _selectedOperationType = '';
   final List<int> _giveTalentKeywordCodes = [];
-  final List<int> _selectedGiveTalentKeywordCodes = [];
+  final List<int> _selectedGiveTalentKeywordCodes = []; //실제로 넘기는 값
   final List<int> _interestTalentKeywordCodes = [];
-  final List<int> _selectedInterestTalentKeywordCodes = [];
+  final List<int> _selectedInterestTalentKeywordCodes = []; //실제로 넘기는 값
   final List<TalentExchangePost> _talentExchangePosts = [];
   Pagination _talentPage = Pagination.empty();
 
@@ -123,8 +123,15 @@ class TalentBoardProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void initTalentExchangePosts(
+      List<TalentExchangePost> addTalentExchangePosts) {
+    _talentExchangePosts.addAll(addTalentExchangePosts);
+    notifyListeners();
+  }
+
   void updateTalentExchangePosts(
       List<TalentExchangePost> addTalentExchangePosts) {
+    _talentExchangePosts.clear();
     _talentExchangePosts.addAll(addTalentExchangePosts);
     notifyListeners();
   }

--- a/lib/view/auth/widget/login_form.dart
+++ b/lib/view/auth/widget/login_form.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import '../../../common/theme.dart';
 import '../../../provider/auth/login_provider.dart';
 import '../../../view_model/auth_view_model.dart';
+import '../../../view_model/talent_board_view_model.dart';
 
 class LoginForm extends StatelessWidget {
   const LoginForm({super.key});
@@ -17,7 +18,7 @@ class LoginForm extends StatelessWidget {
   Widget build(BuildContext context) {
     final loginProvider = Provider.of<LoginProvider>(context);
     final authViewModel = Provider.of<AuthViewModel>(context);
-    // final talentBoardViewModel = Provider.of<TalentBoardViewModel>(context);
+    final talentBoardViewModel = Provider.of<TalentBoardViewModel>(context);
     final commonProvider = Provider.of<CommonProvider>(context);
 
     return Column(
@@ -85,9 +86,13 @@ class LoginForm extends StatelessWidget {
             ),
           ),
         ),
+        //나중에 제거해야 합니다.
         ElevatedButton(
           onPressed: () async {
-            context.go('/match-board-list');
+            commonProvider.changeIsLoading(true);
+            talentBoardViewModel
+                .getTalentExchangePosts()
+                .whenComplete(() => commonProvider.changeIsLoading(false));
           },
           style: ElevatedButton.styleFrom(
             backgroundColor: const Color(0xFF1B76FF),

--- a/lib/view/auth/widget/login_form.dart
+++ b/lib/view/auth/widget/login_form.dart
@@ -90,8 +90,8 @@ class LoginForm extends StatelessWidget {
         ElevatedButton(
           onPressed: () async {
             commonProvider.changeIsLoading(true);
-            talentBoardViewModel
-                .getTalentExchangePosts()
+            await talentBoardViewModel
+                .getInitTalentExchangePosts()
                 .whenComplete(() => commonProvider.changeIsLoading(false));
           },
           style: ElevatedButton.styleFrom(

--- a/lib/view/talent_board/match_board_list.dart
+++ b/lib/view/talent_board/match_board_list.dart
@@ -6,17 +6,21 @@ import 'package:provider/provider.dart';
 import '../../common/theme.dart';
 import '../../common/widget/board_custom_app_bar.dart';
 import '../../provider/talent_board/talent_board_provider.dart';
+import '../../view_model/talent_board_view_model.dart';
 
 class MatchBoardList extends StatelessWidget {
   const MatchBoardList({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final viewModel = Provider.of<TalentBoardViewModel>(context);
     final TalentBoardProvider talentBoardProvider =
         Provider.of<TalentBoardProvider>(context);
+    talentBoardProvider.setViewModel(viewModel);
     return SafeArea(
       child: Scaffold(
         body: CustomScrollView(
+          controller: talentBoardProvider.scrollController,
           slivers: [
             const SliverAppBar(
               pinned: false,
@@ -37,7 +41,6 @@ class MatchBoardList extends StatelessWidget {
               delegate: SliverChildBuilderDelegate(
                 (context, index) {
                   final posts = talentBoardProvider.talentExchangePosts;
-
                   if (posts.isEmpty) {
                     return const Center(
                       child: Padding(

--- a/lib/view/talent_board/match_board_list.dart
+++ b/lib/view/talent_board/match_board_list.dart
@@ -14,34 +14,51 @@ class MatchBoardList extends StatelessWidget {
   Widget build(BuildContext context) {
     final TalentBoardProvider talentBoardProvider =
         Provider.of<TalentBoardProvider>(context);
-    return Scaffold(
-      body: CustomScrollView(
-        slivers: [
-          const SliverAppBar(
-            pinned: false,
-            floating: true,
-            snap: true,
-            backgroundColor: Palette.bgBackGround,
-            elevation: 0,
-            toolbarHeight: 56,
-            leading: null,
-            automaticallyImplyLeading: false,
-            flexibleSpace: BoardCustomAppBar(),
-          ),
-          SliverPersistentHeader(
-            pinned: true,
-            delegate: BoardListTabBar(),
-          ),
-          SliverList(
-            delegate: SliverChildBuilderDelegate(
-              (context, index) {
-                final post = talentBoardProvider.talentExchangePosts[index];
-                return BoardListCard(post: post, index: index);
-              },
-              childCount: talentBoardProvider.talentExchangePosts.length,
+    return SafeArea(
+      child: Scaffold(
+        body: CustomScrollView(
+          slivers: [
+            const SliverAppBar(
+              pinned: false,
+              floating: true,
+              snap: true,
+              backgroundColor: Palette.bgBackGround,
+              elevation: 0,
+              toolbarHeight: 56,
+              leading: null,
+              automaticallyImplyLeading: false,
+              flexibleSpace: BoardCustomAppBar(),
             ),
-          ),
-        ],
+            SliverPersistentHeader(
+              pinned: true,
+              delegate: BoardListTabBar(),
+            ),
+            SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final posts = talentBoardProvider.talentExchangePosts;
+
+                  if (posts.isEmpty) {
+                    return const Center(
+                      child: Padding(
+                        padding: EdgeInsets.all(20.0),
+                        child: Text(
+                          "게시글이 없습니다.",
+                          style: TextStyle(fontSize: 16, color: Colors.grey),
+                        ),
+                      ),
+                    );
+                  }
+
+                  return BoardListCard(post: posts[index], index: index);
+                },
+                childCount: talentBoardProvider.talentExchangePosts.isEmpty
+                    ? 1
+                    : talentBoardProvider.talentExchangePosts.length,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/talent_board/widget/board_list_tab_bar.dart
+++ b/lib/view/talent_board/widget/board_list_tab_bar.dart
@@ -3,7 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../../constants/global_value_constants.dart';
+import '../../../provider/common/common_provider.dart';
 import '../../../provider/talent_board/talent_board_provider.dart';
+import '../../../view_model/talent_board_view_model.dart';
 import 'board_filter_chip.dart';
 import 'keyword_bottom_sheet.dart';
 
@@ -11,8 +13,9 @@ class BoardListTabBar extends SliverPersistentHeaderDelegate {
   @override
   Widget build(
       BuildContext context, double shrinkOffset, bool overlapsContent) {
-    TalentBoardProvider talentBoardProvider =
-        Provider.of<TalentBoardProvider>(context);
+    final talentBoardProvider = Provider.of<TalentBoardProvider>(context);
+    final talentBoardViewModel = Provider.of<TalentBoardViewModel>(context);
+    final commonProvider = Provider.of<CommonProvider>(context);
     return Container(
       height: maxExtent,
       color: Colors.white,
@@ -44,6 +47,8 @@ class BoardListTabBar extends SliverPersistentHeaderDelegate {
                       selectedCode: talentBoardProvider.selectedOrderType,
                       changedFunction: (code) {
                         talentBoardProvider.updateOrderType(code);
+                        getList(commonProvider, talentBoardViewModel,
+                            talentBoardProvider);
                       },
                     );
                   },
@@ -81,8 +86,11 @@ class BoardListTabBar extends SliverPersistentHeaderDelegate {
                             talentBoardProvider
                                 .updateInterestKeywordList(codes);
                           },
-                          registerFunction: () =>
-                              talentBoardProvider.registerInterestKeywordList(),
+                          registerFunction: () {
+                            talentBoardProvider.registerInterestKeywordList();
+                            getList(commonProvider, talentBoardViewModel,
+                                talentBoardProvider);
+                          },
                           resetFunction: () =>
                               talentBoardProvider.resetInterestKeywordList(),
                         );
@@ -122,8 +130,11 @@ class BoardListTabBar extends SliverPersistentHeaderDelegate {
                           updateFunction: (codes) {
                             talentBoardProvider.updateGiveKeywordList(codes);
                           },
-                          registerFunction: () =>
-                              talentBoardProvider.registerGiveKeywordList(),
+                          registerFunction: () {
+                            talentBoardProvider.registerGiveKeywordList();
+                            getList(commonProvider, talentBoardViewModel,
+                                talentBoardProvider);
+                          },
                           resetFunction: () =>
                               talentBoardProvider.resetGiveKeywordList(),
                         );
@@ -159,6 +170,8 @@ class BoardListTabBar extends SliverPersistentHeaderDelegate {
                       selectedCode: talentBoardProvider.selectedOperationType,
                       changedFunction: (code) {
                         talentBoardProvider.updateOperationType(code);
+                        getList(commonProvider, talentBoardViewModel,
+                            talentBoardProvider);
                       },
                     );
                   },
@@ -191,6 +204,8 @@ class BoardListTabBar extends SliverPersistentHeaderDelegate {
                       selectedCode: talentBoardProvider.selectedDurationType,
                       changedFunction: (code) {
                         talentBoardProvider.updateDurationType(code);
+                        getList(commonProvider, talentBoardViewModel,
+                            talentBoardProvider);
                       },
                     );
                   },
@@ -212,5 +227,29 @@ class BoardListTabBar extends SliverPersistentHeaderDelegate {
   @override
   bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) {
     return true;
+  }
+
+  Future<void> getList(
+      CommonProvider commonProvider,
+      TalentBoardViewModel talentBoardViewModel,
+      TalentBoardProvider talentBoardProvider) async {
+    commonProvider.changeIsLoading(true);
+    await talentBoardViewModel
+        .getTalentExchangePosts(
+            talentBoardProvider.selectedGiveTalentKeywordCodes
+                .map((e) => e.toString())
+                .toList(),
+            talentBoardProvider.selectedInterestTalentKeywordCodes
+                .map((e) => e.toString())
+                .toList(),
+            talentBoardProvider.selectedOrderType,
+            talentBoardProvider.selectedDurationType,
+            talentBoardProvider.selectedOperationType,
+            null,
+            null,
+            null,
+            null,
+            null)
+        .whenComplete(() => commonProvider.changeIsLoading(false));
   }
 }

--- a/lib/view/talent_board/widget/match_board_list_card_bottom.dart
+++ b/lib/view/talent_board/widget/match_board_list_card_bottom.dart
@@ -32,7 +32,7 @@ class MatchBoardListCardBottom extends StatelessWidget {
                 SvgPicture.asset('assets/icons/eye_open_grey.svg'),
                 const SizedBox(width: 4),
                 Text(
-                  "${post.count}",
+                  "조회수",
                   style: TextTypes.caption02(color: Palette.text03),
                 ),
               ],
@@ -48,7 +48,7 @@ class MatchBoardListCardBottom extends StatelessWidget {
                 SvgPicture.asset('assets/icons/comment.svg'),
                 const SizedBox(width: 4),
                 Text(
-                  "안정해짐",
+                  "${post.openedChatRoomCount}",
                   style: TextTypes.caption02(color: Palette.text03),
                 ),
               ],

--- a/lib/view_model/talent_board_view_model.dart
+++ b/lib/view_model/talent_board_view_model.dart
@@ -57,7 +57,7 @@ class TalentBoardViewModel extends ChangeNotifier {
             content: ErrorMessages.getMessage(failure.errorCode)), (result) {
       final posts = result['posts'];
       final pagination = result['pagination'];
-      talentBoardProvider.initTalentExchangePosts(posts);
+      talentBoardProvider.updateTalentExchangePosts(posts);
       talentBoardProvider.updateTalentExchangePostsPage(pagination);
       commonNavigator.goRoute('/match-board-list');
     });
@@ -92,6 +92,39 @@ class TalentBoardViewModel extends ChangeNotifier {
       final posts = result['posts'];
       final pagination = result['pagination'];
       talentBoardProvider.updateTalentExchangePosts(posts);
+      talentBoardProvider.updateTalentExchangePostsPage(pagination);
+    });
+  }
+
+  Future<void> addTalentExchangePosts(
+      List<String>? giveTalents,
+      List<String>? receiveTalents,
+      String? order,
+      String? duration,
+      String? type,
+      String? badge,
+      String? status,
+      String? page,
+      String? size,
+      String? search) async {
+    TalentExchangePostsFilterParam param = TalentExchangePostsFilterParam(
+        giveTalents: giveTalents,
+        receiveTalents: receiveTalents,
+        order: order,
+        duration: duration,
+        type: type,
+        badge: badge,
+        status: status,
+        page: page,
+        size: size,
+        search: search);
+    final result = await talentBoardRepository.getTalentExchangePosts(param);
+    result.fold(
+        (failure) => commonNavigator.showSingleDialog(
+            content: ErrorMessages.getMessage(failure.errorCode)), (result) {
+      final posts = result['posts'];
+      final pagination = result['pagination'];
+      talentBoardProvider.addTalentExchangePosts(posts);
       talentBoardProvider.updateTalentExchangePostsPage(pagination);
     });
   }

--- a/lib/view_model/talent_board_view_model.dart
+++ b/lib/view_model/talent_board_view_model.dart
@@ -1,7 +1,9 @@
 import 'package:app_front_talearnt/data/model/param/my_talent_keywords_param.dart';
+import 'package:app_front_talearnt/provider/talent_board/talent_board_provider.dart';
 import 'package:flutter/material.dart';
 
 import '../common/common_navigator.dart';
+import '../data/model/param/talent_exchange_posts_filter_param';
 import '../data/repositories/talent_board_repository.dart';
 import '../provider/talent_board/keyword_provider.dart';
 import '../provider/talent_board/match_write_provider.dart';
@@ -12,12 +14,14 @@ class TalentBoardViewModel extends ChangeNotifier {
   final TalentBoardRepository talentBoardRepository;
   final KeywordProvider keywordProvider;
   final MatchWriteProvider matchWriteProvider;
+  final TalentBoardProvider talentBoardProvider;
 
   TalentBoardViewModel(
     this.commonNavigator,
     this.talentBoardRepository,
     this.keywordProvider,
     this.matchWriteProvider,
+    this.talentBoardProvider,
   );
 
   // Future<void> getKeywords() async {
@@ -41,6 +45,32 @@ class TalentBoardViewModel extends ChangeNotifier {
         (failure) => commonNavigator.showSingleDialog(
             content: ErrorMessages.getMessage(failure.errorCode)), (result) {
       commonNavigator.goRoute('/set-keyword-success');
+    });
+  }
+
+  Future<void> getTalentExchangePosts(
+      // String? categories,
+      // List<int>? talents,
+      // String? order,
+      // String? duration,
+      // String? type,
+      // bool? badge,
+      // String? status,
+      // int? page,
+      // int? size,
+      // String? search
+      ) async {
+    TalentExchangePostsFilterParam param =
+        TalentExchangePostsFilterParam.empty(); //나중에 수정
+    final result = await talentBoardRepository.getTalentExchangePosts(param);
+    result.fold(
+        (failure) => commonNavigator.showSingleDialog(
+            content: ErrorMessages.getMessage(failure.errorCode)), (result) {
+      final posts = result['posts'];
+      final pagination = result['pagination'];
+      talentBoardProvider.updateTalentExchangePosts(posts);
+      talentBoardProvider.updateTalentExchangePostsPage(pagination);
+      commonNavigator.goRoute('/match-board-list');
     });
   }
 }

--- a/lib/view_model/talent_board_view_model.dart
+++ b/lib/view_model/talent_board_view_model.dart
@@ -48,20 +48,43 @@ class TalentBoardViewModel extends ChangeNotifier {
     });
   }
 
-  Future<void> getTalentExchangePosts(
-      // String? categories,
-      // List<int>? talents,
-      // String? order,
-      // String? duration,
-      // String? type,
-      // bool? badge,
-      // String? status,
-      // int? page,
-      // int? size,
-      // String? search
-      ) async {
+  Future<void> getInitTalentExchangePosts() async {
     TalentExchangePostsFilterParam param =
-        TalentExchangePostsFilterParam.empty(); //나중에 수정
+        TalentExchangePostsFilterParam.empty();
+    final result = await talentBoardRepository.getTalentExchangePosts(param);
+    result.fold(
+        (failure) => commonNavigator.showSingleDialog(
+            content: ErrorMessages.getMessage(failure.errorCode)), (result) {
+      final posts = result['posts'];
+      final pagination = result['pagination'];
+      talentBoardProvider.initTalentExchangePosts(posts);
+      talentBoardProvider.updateTalentExchangePostsPage(pagination);
+      commonNavigator.goRoute('/match-board-list');
+    });
+  }
+
+  Future<void> getTalentExchangePosts(
+      List<String>? giveTalents,
+      List<String>? receiveTalents,
+      String? order,
+      String? duration,
+      String? type,
+      String? badge,
+      String? status,
+      String? page,
+      String? size,
+      String? search) async {
+    TalentExchangePostsFilterParam param = TalentExchangePostsFilterParam(
+        giveTalents: giveTalents,
+        receiveTalents: receiveTalents,
+        order: order,
+        duration: duration,
+        type: type,
+        badge: badge,
+        status: status,
+        page: page,
+        size: size,
+        search: search);
     final result = await talentBoardRepository.getTalentExchangePosts(param);
     result.fold(
         (failure) => commonNavigator.showSingleDialog(
@@ -70,7 +93,6 @@ class TalentBoardViewModel extends ChangeNotifier {
       final pagination = result['pagination'];
       talentBoardProvider.updateTalentExchangePosts(posts);
       talentBoardProvider.updateTalentExchangePostsPage(pagination);
-      commonNavigator.goRoute('/match-board-list');
     });
   }
 }


### PR DESCRIPTION
매칭 게시물 리스트 API

- 무한 스크롤 처리
- 필터 변경하면 목록 새로 불러오도록
- 필터해서 목록 없으면 빈칸 나오게
- 서버 수정으로 인한 게시물 목록 param, response 수정
- data 값이 List으로 오는 경우 새로 처리
- DB에서 게시물 리스트 불러오는 API 작성

Resolves : #342