### PR TITLE
TALEARNT 371 : 매칭 게시물 리스트 API - FIX

### DIFF
--- a/lib/data/repositories/board_repository.dart
+++ b/lib/data/repositories/board_repository.dart
@@ -51,8 +51,8 @@ class BoardRepository {
         await dio.get(ApiConstants.getTalentBoardListUrl, null, body.toJson());
     return response.fold(left, (response) {
       final posts = List<MatchingPost>.from(
-          response['data'].map((data) => MatchingPost.fromJson(data)));
-      final pagination = Pagination.fromJson(response['pagination']);
+          response['data']['results'].map((data) => MatchingPost.fromJson(data)));
+      final pagination = Pagination.fromJson(response['data']['pagination']);
       return right({'posts': posts, 'pagination': pagination});
     });
   }


### PR DESCRIPTION
매칭 게시물 리스트 API

- data 안에 results와 pagination 두 개가 담겨 있는 형태로 api result 값 변경

Resolves : #342