### PR TITLE
TALEARNT 383/399/408 : 매칭 커뮤니티 게시물 삭제 API 및 커뮤니티 게시물 상세목록 수정 바텀 탭 판단

### DIFF
--- a/lib/common/widget/dialog.dart
+++ b/lib/common/widget/dialog.dart
@@ -56,9 +56,7 @@ class DoubleBtnDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 40),
-      child: Dialog(
+    return  Dialog(
         backgroundColor: Palette.bgBackGround,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
@@ -123,8 +121,7 @@ class DoubleBtnDialog extends StatelessWidget {
             ],
           ),
         ),
-      ),
-    );
+      );
   }
 }
 

--- a/lib/constants/api_constants.dart
+++ b/lib/constants/api_constants.dart
@@ -29,11 +29,11 @@ abstract class ApiConstants {
 
   static const String getUploadImagesUrl = "$baseUrl/v1/uploads";
 
-  static String getTalentBoard(int postNo) {
+  static String handleMatchDetailBoard(int postNo) {
     return "$baseUrl/v1/posts/exchanges/$postNo";
   }
 
-  static String getCommunityDetailBoard(int postNo) {
+  static String handleCommunityDetailBoard(int postNo) {
     return "$baseUrl/v1/posts/communities/$postNo";
   }
 

--- a/lib/data/repositories/board_repository.dart
+++ b/lib/data/repositories/board_repository.dart
@@ -70,10 +70,10 @@ class BoardRepository {
     });
   }
 
-  Future<Either<Failure, MatchingDetailPost>> getTalentDetailPost(
+  Future<Either<Failure, MatchingDetailPost>> getMatchDetailBoard(
       int postNo) async {
     final response =
-        await dio.get(ApiConstants.getTalentBoard(postNo), null, null);
+        await dio.get(ApiConstants.handleMatchDetailBoard(postNo), null, null);
     return response.fold(
         left, (result) => right(MatchingDetailPost.fromJson(result["data"])));
   }
@@ -99,9 +99,21 @@ class BoardRepository {
 
   Future<Either<Failure, CommunityDetailBoard>> getCommunityDetailBoard(
       int postNo) async {
-    final response =
-        await dio.get(ApiConstants.getCommunityDetailBoard(postNo), null, null);
+    final response = await dio.get(
+        ApiConstants.handleCommunityDetailBoard(postNo), null, null);
     return response.fold(
         left, (result) => right(CommunityDetailBoard.fromJson(result["data"])));
+  }
+
+  Future<Either<Failure, Success>> deleteMatchBoard(int postNo) async {
+    final response =
+        await dio.delete(ApiConstants.handleMatchDetailBoard(postNo));
+    return response.fold(left, (result) => right(Success.fromJson(result)));
+  }
+
+  Future<Either<Failure, Success>> deleteCommunityBoard(int postNo) async {
+    final response =
+        await dio.delete(ApiConstants.handleCommunityDetailBoard(postNo));
+    return response.fold(left, (result) => right(Success.fromJson(result)));
   }
 }

--- a/lib/view/board/board_list.dart
+++ b/lib/view/board/board_list.dart
@@ -80,7 +80,7 @@ class BoardList extends StatelessWidget {
                             overlayColor:
                                 WidgetStateProperty.all(Colors.transparent),
                             onTap: () async {
-                              await viewModel.getTalentDetailPost(
+                              await viewModel.getMatchDetailBoard(
                                   matchBoardProvider.talentExchangePosts[index]
                                       .exchangePostNo);
                             },

--- a/lib/view/board/community_board/community_board_detail_page.dart
+++ b/lib/view/board/community_board/community_board_detail_page.dart
@@ -42,6 +42,9 @@ class CommunityBoardDetailPage extends StatelessWidget {
                   isMine: communityBoardDetailProvider
                           .communityDetailBoard.userNo ==
                       profileProvider.userProfile.userNo,
+                  boardType: 'community',
+                  postNo: communityBoardDetailProvider
+                      .communityDetailBoard.communityPostNo,
                 );
               },
             );

--- a/lib/view/board/match_board/match_board_detail_page.dart
+++ b/lib/view/board/match_board/match_board_detail_page.dart
@@ -39,9 +39,12 @@ class MatchBoardDetailPage extends StatelessWidget {
               clipBehavior: Clip.antiAlias,
               builder: (BuildContext context) {
                 return ModifyBoardBottomSheet(
-                  isMine: matchBoardDetailProvider.matchingDetailPost.userNo ==
-                      profileProvider.userProfile.userNo,
-                );
+                    isMine:
+                        matchBoardDetailProvider.matchingDetailPost.userNo ==
+                            profileProvider.userProfile.userNo,
+                    boardType: 'match',
+                    postNo: matchBoardDetailProvider
+                        .matchingDetailPost.exchangePostNo);
               },
             );
           },

--- a/lib/view/board/widget/modify_board_bottom_sheet.dart
+++ b/lib/view/board/widget/modify_board_bottom_sheet.dart
@@ -1,26 +1,34 @@
 import 'package:app_front_talearnt/common/theme.dart';
+import 'package:app_front_talearnt/provider/board/match_edit_provider.dart';
+import 'package:app_front_talearnt/view_model/keyword_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-
-import 'package:app_front_talearnt/view_model/keyword_view_model.dart';
-import 'package:app_front_talearnt/provider/board/match_edit_provider.dart';
-import '../../../provider/board/match_board_detail_provider.dart';
 import 'package:provider/provider.dart';
+
+import '../../../common/common_navigator.dart';
+import '../../../provider/board/match_board_detail_provider.dart';
+import '../../../view_model/board_view_model.dart';
 
 class ModifyBoardBottomSheet extends StatelessWidget {
   final bool isMine;
+  final String boardType;
+  final int postNo;
 
   const ModifyBoardBottomSheet({
     super.key,
     required this.isMine,
+    required this.boardType,
+    required this.postNo,
   });
 
   @override
   Widget build(BuildContext context) {
     final keywordViewModel = Provider.of<KeywordViewModel>(context);
+    final viewModel = Provider.of<BoardViewModel>(context);
     final matchBoardDetailProvider =
         Provider.of<MatchBoardDetailProvider>(context);
     final matchEditProvider = Provider.of<MatchEditProvider>(context);
+    final commonNavigator = Provider.of<CommonNavigator>(context);
     return Wrap(children: [
       Padding(
         padding: const EdgeInsets.only(bottom: 44, top: 12),
@@ -42,9 +50,8 @@ class ModifyBoardBottomSheet extends StatelessWidget {
                     context.go('/match-edit1');
                   },
                   child: Center(
-                    // 가운데 정렬
                     child: Text(
-                      "수정하기", // 문자열은 따옴표로 감싸야 함
+                      "수정하기",
                       style: TextTypes.body02(
                         color: Palette.text01,
                       ),
@@ -63,12 +70,27 @@ class ModifyBoardBottomSheet extends StatelessWidget {
                   highlightColor: Colors.transparent,
                   hoverColor: Colors.transparent,
                   onTap: () {
-                    context.pop();
+                    if (context.mounted) {
+                      context.pop();
+                    }
+                    commonNavigator.showDoubleDialog(
+                        content: "정말 게시물을 삭제하시겠어요?\n삭제한 게시물은 되돌릴 수 없어요",
+                        leftText: '취소',
+                        rightText: '삭제',
+                        leftFun: () {
+                          commonNavigator.goBack();
+                        },
+                        rightFun: () async {
+                          if (boardType == "match") {
+                            await viewModel.deleteMatchBoard(postNo);
+                          } else {
+                            await viewModel.deleteCommunityBoard(postNo);
+                          }
+                        });
                   },
                   child: Center(
-                    // 가운데 정렬
                     child: Text(
-                      "삭제하기", // 문자열은 따옴표로 감싸야 함
+                      "삭제하기",
                       style: TextTypes.body02(
                         color: Palette.error01,
                       ),
@@ -92,9 +114,8 @@ class ModifyBoardBottomSheet extends StatelessWidget {
                   context.pop();
                 },
                 child: Center(
-                  // 가운데 정렬
                   child: Text(
-                    "취소", // 문자열은 따옴표로 감싸야 함
+                    "취소",
                     style: TextTypes.body02(
                       color: Palette.text04,
                     ),

--- a/lib/view_model/board_view_model.dart
+++ b/lib/view_model/board_view_model.dart
@@ -240,8 +240,8 @@ class BoardViewModel extends ChangeNotifier {
     });
   }
 
-  Future<void> getTalentDetailPost(int postNo) async {
-    final result = await boardRepository.getTalentDetailPost(postNo);
+  Future<void> getMatchDetailBoard(int postNo) async {
+    final result = await boardRepository.getMatchDetailBoard(postNo);
     result.fold(
         (failure) => commonNavigator.showSingleDialog(
             content: ErrorMessages.getMessage(failure.errorCode)), (post) {
@@ -251,7 +251,7 @@ class BoardViewModel extends ChangeNotifier {
   }
 
   Future<void> getEditedPostData(int postNo) async {
-    final result = await boardRepository.getTalentDetailPost(postNo);
+    final result = await boardRepository.getMatchDetailBoard(postNo);
     result.fold(
         (failure) => commonNavigator.showSingleDialog(
             content: ErrorMessages.getMessage(failure.errorCode)), (post) {
@@ -406,6 +406,45 @@ class BoardViewModel extends ChangeNotifier {
             content: ErrorMessages.getMessage(failure.errorCode)), (post) {
       communityBoardDetailProvider.updateCommunityDetailBoard(post);
       commonNavigator.pushRoute('/community-board-detail');
+    });
+  }
+
+  Future<void> deleteMatchBoard(int postNo) async {
+    final result = await boardRepository.deleteMatchBoard(postNo);
+    result.fold(
+        (failure) => commonNavigator.showSingleDialog(
+            content: ErrorMessages.getMessage(failure.errorCode)),
+        (success) async {
+      await getTalentExchangePosts(
+          talentBoardProvider.selectedGiveTalentKeywordCodes
+              .map((e) => e.toString())
+              .toList(),
+          talentBoardProvider.selectedInterestTalentKeywordCodes
+              .map((e) => e.toString())
+              .toList(),
+          talentBoardProvider.selectedOrderType,
+          talentBoardProvider.selectedDurationType,
+          talentBoardProvider.selectedOperationType,
+          null,
+          null,
+          null,
+          null,
+          null);
+      commonNavigator.goBack();
+      commonNavigator.goBack();
+    });
+  }
+
+  Future<void> deleteCommunityBoard(int postNo) async {
+    final result = await boardRepository.deleteCommunityBoard(postNo);
+    result.fold(
+        (failure) => commonNavigator.showSingleDialog(
+            content: ErrorMessages.getMessage(failure.errorCode)),
+        (success) async {
+      await getCommunityBoardList(communityBoardProvider.selectedPostType,
+          communityBoardProvider.selectedOrderType, null, null, null, null);
+      commonNavigator.goBack();
+      commonNavigator.goBack();
     });
   }
 }


### PR DESCRIPTION
매칭 커뮤니티 게시물 삭제 API 및 커뮤니티 게시물 상세목록 수정 바텀 탭 판단

- 커뮤니티 게시물 상세보기 수정 바텀 탭 공통 모듈로 적용
- 매칭 게시물 삭제 API
- 커뮤니티 게시물 삭제 API
- ViewModel 및 Repository 일부 매칭 관련 함수 통일성을 위한 수정

Resolves : #383 #399 #408